### PR TITLE
Update Queries runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,74 @@
+From 60e5d0a2b43b98c75327a3c247b49f478615009e Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Tue, 11 Jun 2024 22:01:56 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ data/io.github.limads.Queries.appdata.xml | 35 +++++++++++++++++------------------
+ 1 file changed, 17 insertions(+), 18 deletions(-)
+
+diff --git a/data/io.github.limads.Queries.appdata.xml b/data/io.github.limads.Queries.appdata.xml
+index 1055421..2a338f6 100644
+--- a/data/io.github.limads.Queries.appdata.xml
++++ b/data/io.github.limads.Queries.appdata.xml
+@@ -10,7 +10,7 @@
+     
+     <project_license>GPL-3.0-or-later</project_license>
+     
+-    <summary>A workbench to interact with relational databases.</summary>
++    <summary>A workbench to interact with relational databases</summary>
+     
+     <description>
+         <p>Queries is a workbench to interact with relational databases, with initial support for Postgres.</p>
+@@ -25,31 +25,30 @@
+         </ul>
+     </description>
+     
+-    <categories>
+-        <category>Office</category>
+-        <category>Development</category>
+-    </categories>
+-    
+-    <keywords>
+-        <keyword translate="no">SQL</keyword>
+-        <keyword translate="no">Database</keyword>
+-        <keyword translate="no">Postgres</keyword>
+-    </keywords>
+-  
++    <launchable type="desktop-id">io.github.limads.Queries.desktop</launchable>
+     <developer_name>Diego Lima</developer_name>
+     
+     <url type="homepage">https://github.com/limads/queries</url>
+     <url type="bugtracker">https://github.com/limads/queries/issues</url>
++    <url type="vcs-browser">https://github.com/limads/queries</url>
+     <url type="donation">https://github.com/sponsors/limads</url>
+     <url type="help">https://github.com/limads/queries/wiki</url>
+     
+     <screenshots>
+-      <screenshot>
+-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen1.png</image>
+-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen2.png</image>
+-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen3.png</image>
+-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen4.png</image>
+-          <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen5.png</image>
++        <screenshot type="default">
++            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen1.png</image>
++        </screenshot>
++        <screenshot>
++            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen2.png</image>
++        </screenshot>
++        <screenshot>
++            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen3.png</image>
++        </screenshot>
++        <screenshot>
++            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen4.png</image>
++        </screenshot>
++        <screenshot>
++            <image>https://limads.sfo3.cdn.digitaloceanspaces.com/queries-screenshots/screen5.png</image>
+         </screenshot>
+     </screenshots>
+     
+--
+libgit2 1.7.2
+

--- a/io.github.limads.Queries.json
+++ b/io.github.limads.Queries.json
@@ -54,6 +54,10 @@
                     "type" : "git",
                     "url" : "https://github.com/limads/queries.git",
                     "tag" : "v0.1.5"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ],
             "post-install" : [

--- a/io.github.limads.Queries.json
+++ b/io.github.limads.Queries.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.limads.Queries",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
- Update Queries runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts.